### PR TITLE
Check http with nounce + add check ports feature

### DIFF
--- a/server.py
+++ b/server.py
@@ -75,8 +75,7 @@ async def check_http(request):
     - get json from body and domain from it
     - check for domain based rate limit (see RATE_LIMIT_SECONDS value)
     - check domain is in valid format
-    - check dns entry for domain match the ip of the request (advanced rule for ipv6)
-    - everything is checked, now try to do an http request on the domain
+    - now try to do an http request on the ip using the domain as target host
     - answer saying if the domain can be reached
     """
 
@@ -122,56 +121,11 @@ async def check_http(request):
             "content": "domain is not in the right format (do not include http:// or https://)",
         }, status=400)
 
-    # TODO handle ipv6
-    # ipv6 situation
-    if ":" in ip:
-        dns_entry = await query_dns(domain, "AAAA")
-
-        if not dns_entry:
-            # check if entry in ip4 for custom error
-            dns_entry = await query_dns(domain, "A")
-
-            # there is an ipv4 entry but the request is made in ipv6, ask to uses ipv4 instead
-            if dns_entry:
-                logger.info(f"[ipv6] Invalid request, no AAAA DNS entry for domain {domain} BUT ipv4 entry, ask user to request in ipv4")
-                return json_response({
-                    "status": "error",
-                    "code": "error_no_ipv6_dns_entry_but_ipv4_dns_entry",
-                    "content": f"there is not AAAA (ipv6) DNS entry for domain {domain} BUT there is an entry in ipv4, please redo the request in ipv4",
-                }, status=400)
-
-            else:
-                logger.info(f"[ipv6] Invalid request, no DNS entry for domain {domain} (both in ipv6 and ip4)")
-                return json_response({
-                    "status": "error",
-                    "code": "error_no_ipv4_ipv6_dns_entry_for_domain",
-                    "content": f"there is not A (ipv4) and AAAA (ipv6) DNS entry for domain {domain}",
-                }, status=400)
-    # ipv4 situation
-    else:
-        dns_entry = await query_dns(domain, "A")
-
-        if not dns_entry:
-            logger.info(f"[ipv4] Invalid request, no DNS entry for domain {domain}")
-            return json_response({
-                "status": "error",
-                "code": "error_no_ipv4_dns_entry_for_domain",
-                "content": f"there is not A (ipv4) and AAAA (ipv6) DNS entry for domain {domain}",
-            }, status=400)
-
-    dns_entry = dns_entry[0]
-
-    if dns_entry.host != ip:
-        logger.info(f"Invalid request, A DNS entry {dns_entry.host} for domain {domain} doesn't match request ip {ip}")
-        return json_response({
-            "status": "error",
-            "code": "error_dns_entry_doesnt_match_request_ip",
-            "content": f"error, the request is made from the ip {ip} but the dns entry said {domain} has the ip {dns_entry.host}, you can only check a domain configured for your ip",
-        }, status=400)
-
     async with aiohttp.ClientSession() as session:
         try:
-            async with session.get("http://" + domain, timeout=aiohttp.ClientTimeout(total=30)) as response:
+            async with session.get("http://" + ip,
+                                   headers={"Host": domain},
+                                   timeout=aiohttp.ClientTimeout(total=30)) as response:
                 # XXX in the futur try to do a double check with the server to
                 # see if the correct content is get
                 await response.text()

--- a/server.py
+++ b/server.py
@@ -259,6 +259,16 @@ async def check_ports(request):
     return json_response({"status": "ok", "ports": result})
 
 
+@app.route("/check-smtp/", methods=["POST"])
+async def check_smtp(request):
+
+    # TODO
+
+    return json_reponse({"status": "error",
+                         "code": "error_not_implemented_yet",
+                         "content": "This is not yet implemented"})
+
+
 @app.route("/")
 async def main(request):
     return html("You aren't really supposed to use this website using your browser.<br><br>It's a small server to check if a YunoHost instance can be reached by http before trying to instal a LE certificate.")

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -119,7 +119,7 @@ async def check_http(request):
         assert data, "Empty request body"
         assert isinstance(data, dict), "Request body ain't a proper dict"
         assert "domains" in data, "No 'domains' provided"
-        assert "nounce" in data, "No 'nounce' provided"
+        assert "nonce" in data, "No 'nonce' provided"
 
         # Check domain list format
         assert isinstance(data["domains"], list), "'domains' ain't a list"
@@ -152,11 +152,11 @@ async def check_http(request):
             }
         }, status=400)
 
-    domain = data["domains"]
+    domains = data["domains"]
     nonce = data["nonce"]
 
     return json_response({
-        "http": {domain: await check_http_domain(ip, domain, nonce)} for domain in domains}
+        "http": {domain: await check_http_domain(ip, domain, nonce) for domain in domains}
     })
 
 

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -264,7 +264,7 @@ async def check_ports(request):
 
         def is_port_number(p):
             return isinstance(p, int) and p > 0 and p < 65535
-        assert all(not is_port_number(p) for p in data["ports"]), "'ports' should a list of valid port numbers"
+        assert all(is_port_number(p) for p in data["ports"]), "'ports' should a list of valid port numbers"
     except AssertionError as e:
         logger.info(f"Invalid request: {e} ... Original request body was: {request.body}")
         return json_response({

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -59,7 +59,10 @@ def check_rate_limit(key, now):
 
 async def check_port_is_open(ip, port):
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if ":" in ip:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(2)
     result = sock.connect_ex((ip, port))
     sock.close()

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -1,7 +1,6 @@
 import re
 import time
 import asyncio
-import aiodns
 import aiohttp
 import validators
 import socket
@@ -12,6 +11,10 @@ from sanic.response import html, json as json_response
 from sanic.exceptions import InvalidUsage
 
 app = Sanic()
+
+# ########################################################################### #
+#   Rate limit                                                                #
+# ########################################################################### #
 
 # keep that in memory
 RATE_LIMIT_DB = {}
@@ -45,9 +48,10 @@ def check_rate_limit(key, now):
         oldest_attempt = RATE_LIMIT_DB[key][0]
         logger.info(f"Rate limit reached for {key}, can retry in {int(RATE_LIMIT_SECONDS - now + oldest_attempt)} seconds")
         return json_response({
-            "status": "error",
-            "code": "error_rate_limit",
-            "content": f"Rate limit reached for this domain or ip, retry in {int(RATE_LIMIT_SECONDS - now + oldest_attempt)} seconds",
+            "error": {
+                "code": "error_rate_limit",
+                "content": f"Rate limit reached for this domain or ip, retry in {int(RATE_LIMIT_SECONDS - now + oldest_attempt)} seconds"
+            }
         }, status=400)
 
     # In any case, add this attempt to the DB
@@ -57,39 +61,17 @@ def check_rate_limit(key, now):
         RATE_LIMIT_DB[key].append(now)
 
 
-async def check_port_is_open(ip, port):
-
-    if ":" in ip:
-        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    else:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    result = sock.connect_ex((ip, port))
-    sock.close()
-    return result == 0
+# ########################################################################### #
+#   HTTP check                                                                #
+# ########################################################################### #
 
 
-# FIXME : remove it ? not used anymore...
-async def query_dns(host, dns_entry_type):
-    loop = asyncio.get_event_loop()
-    dns_resolver = aiodns.DNSResolver(loop=loop)
-
-    try:
-        return await dns_resolver.query(host, dns_entry_type)
-    except aiodns.error.DNSError:
-        return []
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        logger.error("Unhandled error while resolving DNS entry")
-
-
-@app.route("/check-http/", methods=["POST"])
+@app.route("/check-http", methods=["POST"])
 async def check_http(request):
     """
     This function received an HTTP request from a YunoHost instance while this
     server is hosted on our infrastructure. The request is expected to be a
-    POST request with a body like {"domain": "domain-to-check.tld",
+    POST request with a body like {"domains": ["domain1.tld", "domain2.tld"],
                                    "nonce": "1234567890abcdef" }
 
     The nonce value is a single-use ID, and we will try to reach
@@ -101,10 +83,11 @@ async def check_http(request):
     - grab the ip from the request
     - check for ip based rate limit (see RATE_LIMIT_SECONDS value)
     - get json from body and domain from it
-    - check for domain based rate limit (see RATE_LIMIT_SECONDS value)
-    - check domain is in valid format
-    - try to do an http request on the ip (using the domain as target host) for the page /.well-known/ynh-diagnosis/{nonce}
-    - answer saying if the domain can be reached
+    - check for domain-based rate limit (see RATE_LIMIT_SECONDS value)
+    - check domains are in valid format
+    - for each domain:
+        - try to do an http request on the ip (using the domain as target host) for the page /.well-known/ynh-diagnosis/{nonce}
+        - answer saying if the domain can be reached
     """
 
     # this is supposed to be a fast operation if run often enough
@@ -126,53 +109,58 @@ async def check_http(request):
     except InvalidUsage:
         logger.info(f"Invalid json in request, body is: {request.body}")
         return json_response({
-            "status": "error",
-            "code": "error_bad_json",
-            "content": "Invalid usage, body isn't proper json",
+            "error": {
+                "code": "error_bad_json",
+                "content": "Invalid usage, body isn't proper json"
+            }
         }, status=400)
 
-    if not data or "domain" not in data or "nonce" not in data:
-        logger.info(f"Invalid request: didn't specified a domain and a nonce id (body is: {request.body}")
+    try:
+        assert data, "Empty request body"
+        assert isinstance(data, dict), "Request body ain't a proper dict"
+        assert "domains" in data, "No 'domains' provided"
+        assert "nounce" in data, "No 'nounce' provided"
+
+        # Check domain list format
+        assert isinstance(data["domains"], list), "'domains' ain't a list"
+        assert len(data["domains"]) > 0, "'domains' list is empty"
+        assert len(data["domains"]) < 30, "You cannot test that many domains"
+        for domain in data["domains"]:
+            assert isinstance(domain, str), "domain names must be strings"
+            assert len(domain) < 100, "Domain %s name seems pretty long, that's suspicious...?" % domain
+        assert len(data["domains"]) == len(set(data["domains"])), "'domains' list should contain unique elements"
+
+        # Check domain rate limit
+        for domain in data["domains"]:
+            check_rate_limit_domain = check_rate_limit(domain, now)
+            if check_rate_limit_domain:
+                return check_rate_limit_domain
+
+        # Check domains are valid domain names
+        for domain in data["domains"]:
+            assert validators.domain(domain), f"{domain} is not a valid domain"
+
+        # Check nonce format
+        assert isinstance(data["nonce"], str), "'nonce' ain't a string"
+        assert re.match(r"^[a-f0-9]{16}$", data["nonce"]), "'nonce' is not in the right forwat (it should be a 16-digit hexadecimal string)"
+    except AssertionError as e:
+        logger.info(f"Invalid request: {e} ... Original request body was: {request.body}")
         return json_response({
-            "status": "error",
-            "code": "error_no_domain_",
-            "content": "Request must specify a domain and a nonce",
+            "error": {
+                "code": "error_bad_json_data",
+                "content": f"Invalid request: {e} ... Original request body was: {request.body}"
+            }
         }, status=400)
 
-    domain = data["domain"]
-
-    # Since now we are only checking the IP itself, it seems
-    # unecessary to also have a rate limit on domains since the
-    # rate limit on IP will be hit first ...
-    # That would simplify some code, for example we could add the
-    # rate limit check in a decorator for each route/check
-    check_rate_limit_domain = check_rate_limit(domain, now)
-    if check_rate_limit_domain:
-        return check_rate_limit_domain
-
-    if not validators.domain(domain):
-        logger.info(f"Invalid request, is not in the right format (domain is: {domain})")
-        return json_response({
-            "status": "error",
-            "code": "error_domain_bad_format",
-            "content": "domain is not in the right format (do not include http:// or https://)",
-        }, status=400)
-
+    domain = data["domains"]
     nonce = data["nonce"]
 
-    # nonce id is arbitrarily defined to be a
-    # 16-digit hexadecimal string
-    if not re.match(r"^[a-f0-9]{16}$", nonce):
-        logger.info(f"Invalid request, is not in the right format (nonce is: {nonce})")
-        return json_response({
-            "status": "error",
-            "code": "error_nonce_bad_format",
-            "content": "nonce is not in the right format (it should be a 16-digit hexadecimal string)",
-        }, status=400)
+    return json_response({
+        "http": {domain: await check_http_domain(ip, domain, nonce)} for domain in domains}
+    })
 
-    # ############################################# #
-    #  Run the actual check                         #
-    # ############################################# #
+
+async def check_http_domain(ip, domain, nonce):
 
     if ":" in ip:
         ip = "[%s]" % ip
@@ -183,42 +171,44 @@ async def check_http(request):
             async with session.get(url,
                                    headers={"Host": domain},
                                    allow_redirects=False,
-                                   timeout=aiohttp.ClientTimeout(total=10)) as response:
+                                   timeout=aiohttp.ClientTimeout(total=5)) as response:
                 # XXX in the futur try to do a double check with the server to
                 # see if the correct content is get
                 await response.text()
         # TODO various kind of errors
         except (aiohttp.client_exceptions.ServerTimeoutError, asyncio.TimeoutError):
-            return json_response({
-                "status": "error",
-                "code": "error_http_check_timeout",
+            return {
+                "status": "error_http_check_timeout",
                 "content": "Timed-out while trying to contact your server from outside. It appears to be unreachable. You should check that you're correctly forwarding port 80, that nginx is running, and that a firewall is not interfering.",
-            }, status=418)
+            }
         except aiohttp.client_exceptions.ClientConnectorError as e:
-            return json_response({
-                "status": "error",
-                "code": "error_http_check_connection_error",
+            return {
+                "status": "error_http_check_connection_error",
                 "content": "Connection error: could not connect to the requested domain, it's very likely unreachable. Raw error: " + str(e),
-            }, status=418)
+            }
         except Exception as e:
             import traceback
             traceback.print_exc()
 
-            return json_response({
-                "status": "error",
-                "code": "error_http_check_unknown_error",
+            return {
+                "status": "error_http_check_unknown_error",
                 "content": "An error happened while trying to reach your domain, it's very likely unreachable. Raw error: %s" % e,
-            }, status=400)
+            }
 
     if response.status != 200:
-        return json_response({
-            "status": "error",
-            "code": "error_http_check_bad_status_code",
+        return {
+            "status": "error_http_check_bad_status_code",
             "content": "Could not reach your server as expected, it returned code %s. It might be that another machine answered instead of your server. You should check that you're correctly forwarding port 80, that your nginx configuration is up to date, and that a reverse-proxy is not interfering." % response.status,
-        }, status=418)
+        }
     else:
-        logger.info(f"Success when checking http access for {domain} asked by {ip}")
-        return json_response({"status": "ok"})
+        return {
+            "status": "ok"
+        }
+
+
+# ########################################################################### #
+#   Ports check                                                               #
+# ########################################################################### #
 
 
 @app.route("/check-ports/", methods=["POST"])
@@ -256,41 +246,60 @@ async def check_ports(request):
     except InvalidUsage:
         logger.info(f"Invalid json in request, body is: {request.body}")
         return json_response({
-            "status": "error",
-            "code": "error_bad_json",
-            "content": "Invalid usage: body isn't proper json",
+            "error": {
+                "code": "error_bad_json",
+                "content": "Invalid usage, body isn't proper json"
+            }
         }, status=400)
 
-    def is_port_number(p):
-        return isinstance(p, int) and p > 0 and p < 65535
+    try:
+        assert data, "Empty request body"
+        assert isinstance(data, dict), "Request body ain't a proper dict"
+        assert "ports" in data, "No 'ports' provided"
 
-    # Check "ports" exist in request and is a list of port
-    if not data or "ports" not in data:
-        logger.info(f"Invalid request didn't specified a ports list (body is: {request.body}")
+        assert isinstance(data["ports"], list), "'ports' ain't a list"
+        assert len(data["ports"]) > 0, "'ports' list is empty"
+        assert len(data["ports"]) < 30, "That's too many ports to check"
+        assert len(data["ports"]) == len(set(data["ports"])), "'ports' list should contain unique elements"
+
+        def is_port_number(p):
+            return isinstance(p, int) and p > 0 and p < 65535
+        assert all(not is_port_number(p) for p in data["ports"]), "'ports' should a list of valid port numbers"
+    except AssertionError as e:
+        logger.info(f"Invalid request: {e} ... Original request body was: {request.body}")
         return json_response({
-            "status": "error",
-            "code": "error_no_ports_list",
-            "content": "Request must specify a list of ports to check",
+            "error": {
+                "code": "error_bad_json_data",
+                "content": f"Invalid request: {e} ... Original request body was: {request.body}"
+            }
         }, status=400)
-    elif not isinstance(data["ports"], list) or any(not is_port_number(p) for p in data["ports"]) or len(data["ports"]) > 30 or data["ports"] == []:
-        logger.info(f"Invalid request, ports list is not an actual list of ports, or is too long: {request.body}")
-        return json_response({
-            "status": "error",
-            "code": "error_invalid_ports_list",
-            "content": "This is not an acceptable port list: ports must be between 0 and 65535 and at most 30 ports can be checked",
-        }, status=400)
-
-    ports = set(data["ports"])  # Keep only a set so that we get unique ports
 
     # ############################################# #
     #  Run the actual check                         #
     # ############################################# #
 
     result = {}
-    for port in ports:
+    for port in data["ports"]:
         result[int(port)] = await check_port_is_open(ip, port)
 
-    return json_response({"status": "ok", "ports": result})
+    return json_response({"ports": result})
+
+
+async def check_port_is_open(ip, port):
+
+    if ":" in ip:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(2)
+    result = sock.connect_ex((ip, port))
+    sock.close()
+    return result == 0
+
+
+# ########################################################################### #
+#   SMTP check                                                                #
+# ########################################################################### #
 
 
 @app.route("/check-smtp/", methods=["POST"])

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -174,6 +174,9 @@ async def check_http(request):
     #  Run the actual check                         #
     # ############################################# #
 
+    if ":" in ip:
+        ip = "[%s]" % ip
+
     async with aiohttp.ClientSession() as session:
         try:
             url = "http://" + ip + "/.well-known/ynh-diagnosis/" + nonce

--- a/yunodiagnoser.service
+++ b/yunodiagnoser.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=A server providing features for remote-diagnosis for Yunohost servers
+
+[Service]
+Type=simple
+WorkingDirectory={{ WORKING_DIR }}
+ExecStart={{ WORKING_DIR }}/venv/bin/python3.6 yunodiagnoser.py &> server.log
+ExecStop=/bin/kill `/bin/ps aux | /bin/grep yunodiagnoser.py | /bin/grep -v grep | /usr/bin/awk '{ print $2 }'`
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
So here are some proposals of improvements, having in mind the diagnosis mechanism I'm working on where one super helpful check would be the ability to check : 
- if ports are opened, from outside (which doesn't necessarily mean it's the actual server answering)
- check that the actual server is reachable via HTTP
- in the future, might also want to diagnose that the server is reachable via SMTP (though for now already checking port 25 is opened is pretty cool)
- (and writing this, I realize we may also want to check if HTTP*S* can be reached - independently of the status of the certificate)

Various situations need to be covered : 
- the usual "port forwarding not configured at all"
- router answering instead of the server
- another server, in reverse-proxy configuration, answering instead of the actual server
- (in the context of a reverse proxy situation, we can have the actual server answering, but using the wrong certificate because the server in the front is the one defining which cert is to be used)

To provide an accurate feedback with the diagnosis, I think the port / HTTP reachability should be factorized from the DNS record part, so that we can point the user in the right direction, hence b593e6b 

To be able to check that we reach the actual server, I iterated on the `check-http` API to add a `nonce` such that the client is expected to answer 200 to a request for `.well-known/ynh-diagnosis/<nonce_id>` - which should mean that it's not a router or reverse proxy answering. (This is not perfect as, in the worst case scenario, you could imagine the router or reverse proxy answering 200 for *any* url ... So if we want to cover that we could some sort of secret in there). So hence 9a68ffa 

The `check-ports` API in faa81c1 is kinda similar to ports.yunohost.org but integrated in this tool to ~have it in python instead of PHP~, and benefit from the rate limit mechanism 

Regarding the rate limit : dunno what's a good limit, but since we might want to run the HTTP check *once per domain* - which might be something like 10-20 domains for people having a lot of those, maybe we want to move to something more like "not more than 30ish requests per hour" + "not more than 200 per day" ?