### PR TITLE
fix: handle OSError exception on asyncio sockets

### DIFF
--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -182,7 +182,7 @@ async def check_http_domain(ip, domain, nonce):
                 "status": "error_http_check_timeout",
                 "content": "Timed-out while trying to contact your server from outside. It appears to be unreachable. You should check that you're correctly forwarding port 80, that nginx is running, and that a firewall is not interfering.",
             }
-        except aiohttp.client_exceptions.ClientConnectorError as e:
+        except (OSError, aiohttp.client_exceptions.ClientConnectorError) as e:  # OSError: [Errno 113] No route to host
             return {
                 "status": "error_http_check_connection_error",
                 "content": "Connection error: could not connect to the requested domain, it's very likely unreachable. Raw error: " + str(e),

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -295,7 +295,7 @@ async def check_port_is_open(ip, port):
 
     try:
         _, writer = await asyncio.wait_for(futur, timeout=2)
-    except (asyncio.TimeoutError, ConnectionRefusedError):
+    except (asyncio.TimeoutError, ConnectionRefusedError, OSError):  # OSError: [Errno 113] No route to host
         return False
     except Exception:
         import traceback
@@ -350,7 +350,7 @@ async def check_smtp(request):
 
     try:
         reader, writer = await asyncio.wait_for(futur, timeout=2)
-    except (asyncio.TimeoutError, ConnectionRefusedError):
+    except (asyncio.TimeoutError, ConnectionRefusedError, OSError):  # OSError: [Errno 113] No route to host
         return json_response({
             'status': "error_smtp_unreachable",
             'content': "Could not open a connection on port 25, probably because of a firewall or port forwarding issue"


### PR DESCRIPTION
This should handle those tracebacks

```python
Traceback (most recent call last):
  File "/var/www/diagnosis/yunodiagnoser.py", line 297, in check_port_is_open
    _, writer = await asyncio.wait_for(futur, timeout=2)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/asyncio/streams.py", line 81, in open_connection
    lambda: protocol, host, port, **kwds)
  File "uvloop/loop.pyx", line 1974, in create_connection
  File "uvloop/loop.pyx", line 1951, in uvloop.loop.Loop.create_connection
OSError: [Errno 113] No route to host
```