### PR TITLE
Parameterize and Dockerize the service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements-frozen.txt yunodiagnoser.py /app/
+
+RUN pip install --no-cache-dir -r /app/requirements-frozen.txt
+
+CMD ["python3", "/app/yunodiagnoser.py"]

--- a/yunodiagnoser.py
+++ b/yunodiagnoser.py
@@ -13,7 +13,7 @@ from sanic.exceptions import InvalidUsage
 
 app = Sanic(__name__)
 # Don't override values from environment variables
-app.config.setdefault('MAX_DOMAINS', 50)
+app.config.setdefault('MAX_DOMAINS', 60)
 app.config.setdefault('MAX_PORTS', 30)
 
 # ########################################################################### #


### PR DESCRIPTION
Using Sanic's config with ArgumentParser, and by moving the init into a function, we have an app that can run itself or be served using gunicorn, uvicorn etc. with the same default configuration mechanisms

Adding the `Dockerfile` for building a container image and deploying a scalable service

For example, my personal service now runs with support of 100 domains using the following configuration:

`docker-compose.yml`
```yaml
version: "3.7"
services:
  check-http:
    image: uda/check-http:v0.1.1
    environment:
      - SANIC_MAX_DOMAINS=100
    ports:
      - "127.0.0.1:8001:8000"
    restart: unless-stopped
```

Notice that when deploying a custom service it is best to limit the allowed clients in your Load Balancer / Reverse Proxy (nginx, apache etc.)

Notice 2: When running on docker engine you'll need to use a subset of your assigned ipv6 in order to be able to test ipv6 reachability, or manage to configure docker with a working ipv6 NAT (I opted for the first, since it was more straight forward without exposing the ports directly)